### PR TITLE
Update repo URL in package.json. Add MIT LICENSE file to repo

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2020 Branch Metrics, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "prepublishOnly": "npm run build"
   },
   "author": "Bound State Software <info@boundstatesoftware.com>",
-  "homepage": "https://github.com/boundstate/capacitor-branch-deep-links",
+  "homepage": "https://github.com/BranchMetrics/capacitor-branch-deep-links",
   "license": "MIT",
   "dependencies": {
     "@capacitor/core": "latest"
@@ -43,9 +43,9 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/boundstate/capacitor-branch-deep-links"
+    "url": "https://github.com/BranchMetrics/capacitor-branch-deep-links"
   },
   "bugs": {
-    "url": "https://github.com/boundstate/capacitor-branch-deep-links/issues"
+    "url": "https://github.com/BranchMetrics/capacitor-branch-deep-links/issues"
   }
 }


### PR DESCRIPTION
If/once there is a docs site, we should update `homepage` as well instead of just using the repo URL.