### PR TITLE
use explicit capacitor versions instead of @latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,12 +14,12 @@
   "homepage": "https://github.com/BranchMetrics/capacitor-branch-deep-links",
   "license": "MIT",
   "dependencies": {
-    "@capacitor/core": "latest"
+    "@capacitor/core": ">= 1.2.1"
   },
   "devDependencies": {
     "typescript": "^3.2.4",
-    "@capacitor/ios": "latest",
-    "@capacitor/android": "latest"
+    "@capacitor/ios": ">= 1.2.1",
+    "@capacitor/android": ">= 1.2.1"
   },
   "files": [
     "dist/",


### PR DESCRIPTION
Specifying `@latest` breaks the ability to update all `@capacitor` packages in the parent project.  e.g. in my actual app, I cannot do this:  `yarn add @capacitor{core,cli,android,ios}@latest`

The issue has been discussed here:
https://github.com/ionic-team/capacitor/issues/3200

