### PR TITLE
Update plugin to latest capacitor 3.0

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -18,4 +18,5 @@ export default {
       resolveOnly: ['lodash'],
     }),
   ],
+  inlineDynamicImports: true,
 };

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,11 +1,5 @@
 import { PluginListenerHandle } from '@capacitor/core';
 
-declare module '@capacitor/core' {
-  interface PluginRegistry {
-    BranchDeepLinks: BranchDeepLinksPlugin;
-  }
-}
-
 export interface BranchReferringParams {
   '+clicked_branch_link': boolean;
   '+is_first_session': boolean;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,13 @@
+import { registerPlugin } from '@capacitor/core';
+
+import type { BranchDeepLinksPlugin } from './definitions';
+
+const BranchDeepLinks = registerPlugin<BranchDeepLinksPlugin>(
+  'BranchDeepLinks',
+  {
+    web: () => import('./web').then(m => new m.BranchDeepLinksWeb()),
+  },
+);
+
 export * from './definitions';
-export * from './web';
+export { BranchDeepLinks };

--- a/src/web.ts
+++ b/src/web.ts
@@ -77,6 +77,3 @@ export class BranchDeepLinksWeb extends WebPlugin
 const BranchDeepLinks = new BranchDeepLinksWeb();
 
 export { BranchDeepLinks };
-
-import { registerWebPlugin } from '@capacitor/core';
-registerWebPlugin(BranchDeepLinks);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,9 +5,9 @@
     "esModuleInterop": true,
     "lib": [
       "dom",
-      "es2015"
+      "es2017"
     ],
-    "module": "es2015",
+    "module": "esnext",
     "moduleResolution": "node",
     "noFallthroughCasesInSwitch": true,
     "noUnusedLocals": true,
@@ -16,7 +16,7 @@
     "pretty": true,
     "sourceMap": true,
     "strict": true,
-    "target": "es2015"
+    "target": "es2017"
   },
   "files": [
     "src/index.ts"


### PR DESCRIPTION
Now that Capacitor 3.0 has officially launched we have all the specifics to upgrade the plugin.