### PR TITLE
Update iOS deployment target from 12 to 13 to prevent compile error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Branch Capacitor SDK change log
 
+- 5.0.1
+
+  - Update iOS deployment target from 12 to 13 to prevent compilation error in xcode
+
 - 5.0.0
 
   - Updates the core capacitor plugin to 4.0.1

--- a/CapacitorBranchDeepLinks.podspec
+++ b/CapacitorBranchDeepLinks.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.author = package['author']
   s.source = { :git => package['repository']['url'], :tag => s.version.to_s }
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
-  s.ios.deployment_target  = '12.0'
+  s.ios.deployment_target  = '13.0'
   s.dependency 'Capacitor'
   s.dependency 'Branch'
   s.swift_version = '5.1'

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -16,7 +16,7 @@ public class BranchDeepLinks: CAPPlugin {
                 object: nil
         )
         
-        Branch.getInstance().registerPluginName("Capacitor", version: "5.0.0")
+        Branch.getInstance().registerPluginName("Capacitor", version: "5.0.1")
     }
 
     @objc public func setBranchService(branchService: Any) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capacitor-branch-deep-links",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Capacitor plugin for Branch.io deep links",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
This resolves issue 65:
https://github.com/BranchMetrics/capacitor-branch-deep-links/issues/65