### PR TITLE
Add ATT result handling to iOS

### DIFF
--- a/ios/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin.m
@@ -8,6 +8,7 @@ CAP_PLUGIN(BranchDeepLinks, "BranchDeepLinks",
            CAP_PLUGIN_METHOD(showShareSheet, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(getStandardEvents, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(sendBranchEvent, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(handleATTAuthorizationStatus, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(disableTracking, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(setIdentity, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(logout, CAPPluginReturnPromise);

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -66,6 +66,16 @@ public class BranchDeepLinks: CAPPlugin {
         }
     }
 
+    @objc func handleATTAuthorizationStatus(_ call: CAPPluginCall) {
+        if let value = call.getInt("status") {
+            Branch.getInstance().handleATTAuthorizationStatus(UInt(value))
+            call.resolve()
+        }
+
+        call.reject("No status was provided.")
+    }
+
+
     @objc func showShareSheet(_ call: CAPPluginCall) {
         let analytics = call.getObject("analytics") ?? [:]
         let properties = call.getObject("properties") ?? [:]

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -77,6 +77,8 @@ export interface BranchQRCodeResponse {
 
 export interface BranchInitEvent extends BranchReferringParamsResponse {}
 
+export type BranchATTAuthorizationStatus = 0 | 1 | 2 | 3;
+
 export interface BranchDeepLinksPlugin {
   addListener(
     eventName: 'init',
@@ -95,6 +97,9 @@ export interface BranchDeepLinksPlugin {
   sendBranchEvent(options: {
     eventName: string;
     metaData: { [key: string]: any };
+  }): Promise<void>;
+  handleATTAuthorizationStatus(options: {
+    status: BranchATTAuthorizationStatus
   }): Promise<void>;
   disableTracking(options: {
     isEnabled: false;

--- a/src/web.ts
+++ b/src/web.ts
@@ -55,6 +55,14 @@ export class BranchDeepLinksWeb extends WebPlugin
     );
   }
 
+  handleATTAuthorizationStatus(_: {
+    status: number
+  }): Promise<void> {
+    return Promise.reject(
+      new Error('BranchDeepLinks does not have web implementation'),
+    );
+  }
+
   disableTracking(_: { isEnabled: false }): Promise<BranchTrackingResponse> {
     return Promise.reject(
       new Error('BranchDeepLinks does not have web implementation'),


### PR DESCRIPTION
## Reference
SDK-XXXX -- <TITLE>.

## Summary
This patch adds ATT handling for iOS. It is already in the [ReactNative version](https://github.com/BranchMetrics/react-native-branch-deep-linking-attribution/commit/d4d270b352f2365edf53862ded3d77e15b2e793d).

## Motivation
Without this change, ATT prompt opt-in doesn't affect Branch.

## Type Of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## Testing Instructions
Pass in the results of the ATT prompt to the provided function. 

Note that you'll either need to do the ATT prompt yourself or you'll need another package like [`capacitor-plugin-app-tracking-transparency`](https://github.com/mahnuh/capacitor-plugin-app-tracking-transparency)

Example:

```
handleATTAuthorizationStatus(trackingStatus: AppTrackingStatus) {
    if (Capacitor.isNativePlatform() && this.platform.is('ios')) {
      let status: BranchATTAuthorizationStatus;
      // Convert the strings back to the correct integer value.
      switch(trackingStatus) {
        case 'authorized':
          status = 3;
          break;
        case 'denied':
          status = 2;
          break;
        case 'notDetermined':
          status = 0;
          break;
        case 'restricted':
          status = 1;
          break;
      }
      BranchDeepLinks.handleATTAuthorizationStatus({status});
    }
  }
```

I have been in contact with support about this. This change is a merge of our working copy of the code with Branch's official code.
