### PR TITLE
[SDK-2050] Added referringParams methods

### DIFF
--- a/android/src/main/java/co/boundstate/BranchDeepLinks.java
+++ b/android/src/main/java/co/boundstate/BranchDeepLinks.java
@@ -518,4 +518,18 @@ public class BranchDeepLinks extends Plugin {
 
         return shareLinkBuilder;
     }
+
+    @PluginMethod
+    public void getLatestReferringParams(PluginCall call) {
+        JSObject ret = new JSObject();
+        ret.put("referringParams", Branch.getInstance().getLatestReferringParams());
+        call.resolve(ret);
+    }
+
+    @PluginMethod
+    public void getFirstReferringParams(PluginCall call) {
+        JSObject ret = new JSObject();
+        ret.put("referringParams", Branch.getInstance().getFirstReferringParams());
+        call.resolve(ret);
+    }
 }

--- a/ios/Plugin/BranchService.swift
+++ b/ios/Plugin/BranchService.swift
@@ -43,8 +43,18 @@ class BranchService {
                 completion(nil, error)
             } else if let qrCodeData = qrCodeData {
                 let qrCodeString = qrCodeData.base64EncodedString()
-                completion(qrCodeString,nil)
+                completion(qrCodeString, nil)
             }
         }
+    }
+
+   func getLatestReferringParams(completion: @escaping ([AnyHashable: Any])->(Void)) -> Void {
+        let params = Branch.getInstance().getLatestReferringParams() ?? [:]
+        completion(params)
+    }
+
+    func getFirstReferringParams(completion: @escaping ([AnyHashable : Any])->(Void)) -> Void {
+        let params = Branch.getInstance().getFirstReferringParams() ?? [:]
+        completion(params)
     }
 }

--- a/ios/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin.m
@@ -13,4 +13,6 @@ CAP_PLUGIN(BranchDeepLinks, "BranchDeepLinks",
            CAP_PLUGIN_METHOD(setIdentity, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(logout, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(getBranchQRCode, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(getLatestReferringParams, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(getFirstReferringParams, CAPPluginReturnPromise);
 )

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -313,4 +313,20 @@ public class BranchDeepLinks: CAPPlugin {
         hexInt = UInt32(bitPattern: scanner.scanInt32(representation: .hexadecimal) ?? 0)
         return hexInt
     }
+
+    @objc func getLatestReferringParams(_ call: CAPPluginCall) {
+        branchService.getLatestReferringParams() { (params) in
+            call.resolve([
+                "referringParams": params 
+            ])
+        }
+    }
+
+    @objc func getFirstReferringParams(_ call: CAPPluginCall) {
+        branchService.getFirstReferringParams() { (params) in
+            call.resolve([
+                "referringParams": params 
+            ])
+        }
+    }
 }

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,11 +1,11 @@
 PODS:
-  - BranchSDK (2.2.0)
-  - Capacitor (5.0.5):
+  - BranchSDK (3.0.1)
+  - Capacitor (5.5.1):
     - CapacitorCordova
-  - CapacitorCordova (5.0.5)
+  - CapacitorCordova (5.5.1)
 
 DEPENDENCIES:
-  - BranchSDK (~> 2.2.0)
+  - BranchSDK (~> 3.0.1)
   - "Capacitor (from `../node_modules/@capacitor/ios`)"
   - "CapacitorCordova (from `../node_modules/@capacitor/ios`)"
 
@@ -20,10 +20,10 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@capacitor/ios"
 
 SPEC CHECKSUMS:
-  BranchSDK: 8749d10e30725d08b6c188ab90e6fd6223d204db
-  Capacitor: b1248915663add1bd6567e2b67c1c1fa3abcf5e8
-  CapacitorCordova: f8c06b897c74ee8f7701fe10e6443b40822bc83a
+  BranchSDK: e268bcf41469051c9e83efcd6fd85d0ba91d1d0f
+  Capacitor: 9da0a2415e3b6098511f8b5ffdb578d91ee79f8f
+  CapacitorCordova: e128cc7688c070ca0bfa439898a5f609da8dbcfe
 
-PODFILE CHECKSUM: 8d82a5f2a904341bee78b56626ba4183204a9f0d
+PODFILE CHECKSUM: c730e0536dc486077a354a5b012e11d630c85889
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.12.1

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -99,7 +99,7 @@ export interface BranchDeepLinksPlugin {
     metaData: { [key: string]: any };
   }): Promise<void>;
   handleATTAuthorizationStatus(options: {
-    status: BranchATTAuthorizationStatus
+    status: BranchATTAuthorizationStatus;
   }): Promise<void>;
   disableTracking(options: {
     isEnabled: false;
@@ -108,7 +108,7 @@ export interface BranchDeepLinksPlugin {
     newIdentity: string;
   }): Promise<BranchReferringParamsResponse>;
   logout(): Promise<BranchLoggedOutResponse>;
-  getBranchQRCode(
-    options: BranchQRCodeParams,
-  ): Promise<BranchQRCodeResponse>;
+  getBranchQRCode(options: BranchQRCodeParams): Promise<BranchQRCodeResponse>;
+  getLatestReferringParams(): Promise<BranchReferringParamsResponse>;
+  getFirstReferringParams(): Promise<BranchReferringParamsResponse>;
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -13,8 +13,10 @@ import {
   BranchQRCodeResponse,
 } from './definitions';
 
-export class BranchDeepLinksWeb extends WebPlugin
-  implements BranchDeepLinksPlugin {
+export class BranchDeepLinksWeb
+  extends WebPlugin
+  implements BranchDeepLinksPlugin
+{
   constructor() {
     super({
       name: 'BranchDeepLinks',
@@ -55,9 +57,7 @@ export class BranchDeepLinksWeb extends WebPlugin
     );
   }
 
-  handleATTAuthorizationStatus(_: {
-    status: number
-  }): Promise<void> {
+  handleATTAuthorizationStatus(_: { status: number }): Promise<void> {
     return Promise.reject(
       new Error('BranchDeepLinks does not have web implementation'),
     );
@@ -88,6 +88,16 @@ export class BranchDeepLinksWeb extends WebPlugin
       new Error('BranchDeepLinks does not have web implementation'),
     );
   }
+
+  getLatestReferringParams(): Promise<BranchReferringParamsResponse> {
+    return Promise.reject(
+      new Error('BranchDeepLinks does not have web implementation'),
+    );
+  }
+
+  getFirstReferringParams(): Promise<BranchReferringParamsResponse> {
+    return Promise.reject(
+      new Error('BranchDeepLinks does not have web implementation'),
+    );
+  }
 }
-
-


### PR DESCRIPTION
## Reference
SDK-2050 -- add getLatestReferringParams

## Summary
Added methods for `getLatestReferringParams()` and `getFirstReferringParams()`. There are also some small formatting changes.

## Motivation
There was a GitHub issue which requested it and this brings more parity between the native and plugin SDKs.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] New feature (non-breaking change which adds functionality)

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->
Run a test app with the `7.0.0-alpha.2` version of the plugin and test the new methods.

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.