### PR TITLE
[SDK-2252] Expose the setDMAParamsForEEA method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 Branch Capacitor SDK change log
 
+- 7.1.0
+
+  - Added new method, setDMAParamsForEEA(), for setting DMA compliance parameters.
+  - Branch Android SDK bumped to 5.9.0
+  - Branch iOS SDK bumped to 3.3.0
+
 - 7.0.0
 
   - Branch Android SDK bumped to 5.7.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Branch Capacitor SDK change log
 
   - Added new method, setDMAParamsForEEA(), for setting DMA compliance parameters.
   - Branch Android SDK bumped to 5.9.0
-  - Branch iOS SDK bumped to 3.3.0
+  - Branch iOS SDK bumped to 3.2.0
 
 - 7.0.0
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     implementation project(':capacitor-android')
     implementation 'androidx.annotation:annotation:1.4.0'
     implementation 'androidx.appcompat:appcompat:1.5.0'
-    api 'io.branch.sdk.android:library:5.7.5'
+    api 'io.branch.sdk.android:library:5.9.0'
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"

--- a/android/src/main/java/co/boundstate/BranchDeepLinks.java
+++ b/android/src/main/java/co/boundstate/BranchDeepLinks.java
@@ -532,4 +532,10 @@ public class BranchDeepLinks extends Plugin {
         ret.put("referringParams", Branch.getInstance().getFirstReferringParams());
         call.resolve(ret);
     }
+
+    @PluginMethod
+    public void setDMAParamsForEEA(boolean eeaRegion, boolean adPersonalizationConsent, boolean adUserDataUsageConsent) {
+        Branch branch = Branch.getInstance();
+        branch.setDMAParamsForEEA(eeaRegion, adPersonalizationConsent, adUserDataUsageConsent);
+    }
 }

--- a/android/src/main/java/co/boundstate/BranchDeepLinks.java
+++ b/android/src/main/java/co/boundstate/BranchDeepLinks.java
@@ -535,9 +535,14 @@ public class BranchDeepLinks extends Plugin {
 
     @PluginMethod
     public void setDMAParamsForEEA(PluginCall call) {
-        Boolean eeaRegion = call.getBoolean("eeaRegion", false);
-        Boolean adPersonalizationConsent = call.getBoolean("adPersonalizationConsent", false);
-        Boolean adUserDataUsageConsent = call.getBoolean("adUserDataUsageConsent", false);
+        Boolean eeaRegion = call.getBoolean("eeaRegion");
+        Boolean adPersonalizationConsent = call.getBoolean("adPersonalizationConsent");
+        Boolean adUserDataUsageConsent = call.getBoolean("adUserDataUsageConsent");
+
+        if (eeaRegion == null || adPersonalizationConsent == null || adUserDataUsageConsent == null) {
+            call.reject("Must provide valid eeaRegion, adPersonalizationConsent, and adUserDataUsageConsent");
+            return;
+        }
 
         Branch branch = Branch.getInstance();
         branch.setDMAParamsForEEA(eeaRegion, adPersonalizationConsent, adUserDataUsageConsent);

--- a/android/src/main/java/co/boundstate/BranchDeepLinks.java
+++ b/android/src/main/java/co/boundstate/BranchDeepLinks.java
@@ -534,8 +534,14 @@ public class BranchDeepLinks extends Plugin {
     }
 
     @PluginMethod
-    public void setDMAParamsForEEA(boolean eeaRegion, boolean adPersonalizationConsent, boolean adUserDataUsageConsent) {
+    public void setDMAParamsForEEA(PluginCall call) {
+        Boolean eeaRegion = call.getBoolean("eeaRegion", false);
+        Boolean adPersonalizationConsent = call.getBoolean("adPersonalizationConsent", false);
+        Boolean adUserDataUsageConsent = call.getBoolean("adUserDataUsageConsent", false);
+
         Branch branch = Branch.getInstance();
         branch.setDMAParamsForEEA(eeaRegion, adPersonalizationConsent, adUserDataUsageConsent);
+
+        call.resolve();
     }
 }

--- a/ios/Plugin/BranchService.swift
+++ b/ios/Plugin/BranchService.swift
@@ -59,6 +59,6 @@ class BranchService {
     }
 
     func setDMAParamsForEEA(eeaRegion: Bool, adPersonalizationConsent: Bool, adUserDataUsageConsent: Bool) -> Void {
-        Branch.getInstance().setDMAData(eeaRegion, adPersonalizationConsent: adPersonalizationConsent, adUserDataUsageConsent: adUserDataUsageConsent)
+        Branch.setDMAParamsForEEA(eeaRegion, adPersonalizationConsent: adPersonalizationConsent, adUserDataUsageConsent: adUserDataUsageConsent)
     }
 }

--- a/ios/Plugin/BranchService.swift
+++ b/ios/Plugin/BranchService.swift
@@ -57,4 +57,8 @@ class BranchService {
         let params = Branch.getInstance().getFirstReferringParams() ?? [:]
         completion(params)
     }
+
+    func setDMAParamsForEEA(eeaRegion: Bool, adPersonalizationConsent: Bool, adUserDataUsageConsent: Bool) -> Void {
+        Branch.getInstance().setDMAData(eeaRegion, adPersonalizationConsent: adPersonalizationConsent, adUserDataUsageConsent: adUserDataUsageConsent)
+    }
 }

--- a/ios/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin.m
@@ -15,4 +15,5 @@ CAP_PLUGIN(BranchDeepLinks, "BranchDeepLinks",
            CAP_PLUGIN_METHOD(getBranchQRCode, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(getLatestReferringParams, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(getFirstReferringParams, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(setDMAParamsForEEA, CAPPluginReturnPromise);
 )

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -329,4 +329,12 @@ public class BranchDeepLinks: CAPPlugin {
             ])
         }
     }
+
+    @objc func setDMAParamsForEEA(_ call: CAPPluginCall) {
+        let eeaRegion = call.getBool("eeaRegion") ?? false
+        let adPersonalizationConsent = call.getBool("adPersonalizationConsent") ?? false
+        let adUserDataUsageConsent = call.getBool("adUserDataUsageConsent") ?? false
+        branchService.setDMAParamsForEEA(eeaRegion: eeaRegion, adPersonalizationConsent: adPersonalizationConsent, adUserDataUsageConsent: adUserDataUsageConsent)
+        call.resolve()
+    }
 }

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -87,10 +87,10 @@ public class BranchDeepLinks: CAPPlugin {
 
         let buo = BranchUniversalObject.init()
         DispatchQueue.main.async {
-            buo.showShareSheet(with: linkProperties, andShareText: shareText, from: self.bridge?.viewController, completion: nil)
+            buo.showShareSheet(with: linkProperties, andShareText: shareText, from: self.bridge?.viewController)
         }
 
-        call.success()
+        call.resolve()
     }
 
     @objc func getStandardEvents(_ call: CAPPluginCall) {
@@ -165,7 +165,7 @@ public class BranchDeepLinks: CAPPlugin {
         }
 
         event.logEvent()
-        call.success()
+        call.resolve()
     }
 
     @objc func disableTracking(_ call: CAPPluginCall) {

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -331,9 +331,12 @@ public class BranchDeepLinks: CAPPlugin {
     }
 
     @objc func setDMAParamsForEEA(_ call: CAPPluginCall) {
-        let eeaRegion = call.getBool("eeaRegion") ?? false
-        let adPersonalizationConsent = call.getBool("adPersonalizationConsent") ?? false
-        let adUserDataUsageConsent = call.getBool("adUserDataUsageConsent") ?? false
+
+        guard let eeaRegion = call.getBool("eeaRegion"), let adPersonalizationConsent = call.getBool("adPersonalizationConsent"), let adUserDataUsageConsent = call.getBool("adUserDataUsageConsent") else {
+            call.reject("One or more DMA parameters are missing")
+            return
+        }
+
         branchService.setDMAParamsForEEA(eeaRegion: eeaRegion, adPersonalizationConsent: adPersonalizationConsent, adUserDataUsageConsent: adUserDataUsageConsent)
         call.resolve()
     }

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -4,7 +4,7 @@ def capacitor_pods
   use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
-  pod 'BranchSDK', '~> 3.0.1'
+  pod 'BranchSDK', '~> 3.3.0'
 end
 
 target 'Plugin' do

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -4,7 +4,7 @@ def capacitor_pods
   use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
-  pod 'BranchSDK', '~> 3.3.0'
+  pod 'BranchSDK', '~> 3.2.0'
 end
 
 target 'Plugin' do

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capacitor-branch-deep-links",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Capacitor plugin for Branch.io deep links",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -75,6 +75,12 @@ export interface BranchQRCodeResponse {
   qrCode: String;
 }
 
+export interface BranchDMAParams {
+  eeaRegion: boolean;
+  adPersonalizationConsent: boolean;
+  adUserDataUsageConsent: boolean;
+}
+
 export interface BranchInitEvent extends BranchReferringParamsResponse {}
 
 export type BranchATTAuthorizationStatus = 0 | 1 | 2 | 3;
@@ -111,9 +117,5 @@ export interface BranchDeepLinksPlugin {
   getBranchQRCode(options: BranchQRCodeParams): Promise<BranchQRCodeResponse>;
   getLatestReferringParams(): Promise<BranchReferringParamsResponse>;
   getFirstReferringParams(): Promise<BranchReferringParamsResponse>;
-  setDMAParamsForEEA: (
-    eeaRegion: boolean,
-    adPersonalizationConsent: boolean,
-    adUserDataUsageConsent: boolean,
-  ) => void;
+  setDMAParamsForEEA: (options: BranchDMAParams) => void;
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -111,4 +111,9 @@ export interface BranchDeepLinksPlugin {
   getBranchQRCode(options: BranchQRCodeParams): Promise<BranchQRCodeResponse>;
   getLatestReferringParams(): Promise<BranchReferringParamsResponse>;
   getFirstReferringParams(): Promise<BranchReferringParamsResponse>;
+  setDMAParamsForEEA: (
+    eeaRegion: boolean,
+    adPersonalizationConsent: boolean,
+    adUserDataUsageConsent: boolean,
+  ) => void;
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -100,4 +100,14 @@ export class BranchDeepLinksWeb
       new Error('BranchDeepLinks does not have web implementation'),
     );
   }
+
+  setDMAParamsForEEA(
+    _eeaRegion: boolean,
+    _adPersonalizationConsent: boolean,
+    _adUserDataUsageConsent: boolean,
+  ): Promise<void> {
+    return Promise.reject(
+      new Error('BranchDeepLinks does not have web implementation'),
+    );
+  }
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -11,6 +11,7 @@ import {
   BranchTrackingResponse,
   BranchQRCodeParams,
   BranchQRCodeResponse,
+  BranchDMAParams,
 } from './definitions';
 
 export class BranchDeepLinksWeb
@@ -101,11 +102,7 @@ export class BranchDeepLinksWeb
     );
   }
 
-  setDMAParamsForEEA(
-    _eeaRegion: boolean,
-    _adPersonalizationConsent: boolean,
-    _adUserDataUsageConsent: boolean,
-  ): Promise<void> {
+  setDMAParamsForEEA(_: BranchDMAParams): Promise<void> {
     return Promise.reject(
       new Error('BranchDeepLinks does not have web implementation'),
     );


### PR DESCRIPTION
## Reference
SDK-2249 -- Expose the setDMAParamsForEEA method

## Summary
Expose the setDMAParamsForEEA method in the JS layer and bump the native SDK versions.

## Motivation
So clients can utilize the method in Capacitor and stay compliant.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] New feature (non-breaking change which adds functionality)

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->
1. In a test app, install the `capacitor-branch-deep-links@7.1.0-alpha.2` to get the latest version of our SDK with the new method.
2. Call the method like `BranchDeepLinks.setDMAParamsForEEA({true, true, true});` 
3. Observe the following request payloads for the respective DMA fields; `dma_eea, dma_ad_personalization, dma_ad_user_data .`

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
