### PR TITLE
Switch order of literals to prevent NullPointerException

### DIFF
--- a/android/src/main/java/co/boundstate/BranchDeepLinks.java
+++ b/android/src/main/java/co/boundstate/BranchDeepLinks.java
@@ -191,31 +191,31 @@ public class BranchDeepLinks extends Plugin {
 
         while (keys.hasNext()) {
             String key = keys.next();
-            if (key.equals("revenue")) {
+            if ("revenue".equals(key)) {
                 event.setRevenue(Double.parseDouble(metaData.getString("revenue")));
-            } else if (key.equals("currency")) {
+            } else if ("currency".equals(key)) {
                 String currencyString = metaData.getString("currency");
                 CurrencyType currency = CurrencyType.getValue(currencyString);
                 if (currency != null) {
                     event.setCurrency(currency);
                 }
-            } else if (key.equals("transactionID")) {
+            } else if ("transactionID".equals(key)) {
                 event.setTransactionID(metaData.getString("transactionID"));
-            } else if (key.equals("coupon")) {
+            } else if ("coupon".equals(key)) {
                 event.setCoupon(metaData.getString("coupon"));
-            } else if (key.equals("shipping")) {
+            } else if ("shipping".equals(key)) {
                 event.setShipping(Double.parseDouble(metaData.getString("shipping")));
-            } else if (key.equals("tax")) {
+            } else if ("tax".equals(key)) {
                 event.setTax(Double.parseDouble(metaData.getString("tax")));
-            } else if (key.equals("affiliation")) {
+            } else if ("affiliation".equals(key)) {
                 event.setAffiliation(metaData.getString("affiliation"));
-            } else if (key.equals("description")) {
+            } else if ("description".equals(key)) {
                 event.setDescription(metaData.getString("description"));
-            } else if (key.equals("searchQuery")) {
+            } else if ("searchQuery".equals(key)) {
                 event.setSearchQuery(metaData.getString("searchQuery"));
-            } else if (key.equals("customerEventAlias")) {
+            } else if ("customerEventAlias".equals(key)) {
                 event.setCustomerEventAlias(metaData.getString("customerEventAlias"));
-            } else if (key.equals("customData")) {
+            } else if ("customData".equals(key)) {
                 JSONObject customData = metaData.getJSObject("customData");
                 keys = customData.keys();
 
@@ -223,7 +223,7 @@ public class BranchDeepLinks extends Plugin {
                     String keyValue = (String) keys.next();
                     event.addCustomDataProperty(keyValue, customData.getString(keyValue));
                 }
-            } else if (key.equals("contentMetadata")) {
+            } else if ("contentMetadata".equals(key)) {
                 JSONArray contentMetadata = metaData.getJSONArray("contentMetadata");
 
                 for (int i = 0; i < contentMetadata.length(); i++) {


### PR DESCRIPTION
This change defensively switches the order of literals in comparison expressions to ensure that no null pointer exceptions are unexpectedly thrown. Runtime exceptions especially can cause exceptional and unexpected code paths to be taken, and this can result in unexpected behavior. 

Both simple vulnerabilities (like information disclosure) and complex vulnerabilities (like business logic flaws) can take advantage of these unexpected code paths.

Our changes look something like this:

```diff
  String fieldName = header.getFieldName();
  String fieldValue = header.getFieldValue();
- if(fieldName.equals("requestId")) {
+ if("requestId".equals(fieldName)) {
    logRequest(fieldValue);
  }
```

<details>
  <summary>More reading</summary>

  * [https://cwe.mitre.org/data/definitions/476.html](https://cwe.mitre.org/data/definitions/476.html)
  * [https://en.wikibooks.org/wiki/Java_Programming/Preventing_NullPointerException](https://en.wikibooks.org/wiki/Java_Programming/Preventing_NullPointerException)
  * [https://rules.sonarsource.com/java/RSPEC-1132/](https://rules.sonarsource.com/java/RSPEC-1132/)
</details>

🧚🤖  Powered by Pixeebot  

💬[Feedback](https://ask.pixee.ai/feedback) | 👥[Community](https://pixee-community.slack.com/signup#/domain-signup) | 📚[Docs](https://docs.pixee.ai/) | Codemod ID: [pixee:java/switch-literal-first](https://docs.pixee.ai/codemods/java/pixee_java_switch-literal-first) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Java%2Fcapacitor-branch-deep-links%7C08b4488a99acb929f3ccee86d6ee10a7fd72e174)


<!--{"type":"DRIP","codemod":"pixee:java/switch-literal-first"}-->