### PR TITLE
Fix Push Notifications for Android and iOS in Capacitor SDK

### DIFF
--- a/android/src/main/java/co/boundstate/BranchDeepLinks.java
+++ b/android/src/main/java/co/boundstate/BranchDeepLinks.java
@@ -106,7 +106,7 @@ public class BranchDeepLinks extends Plugin {
     public void handleUrl(PluginCall call) {
         // https://help.branch.io/developers-hub/docs/android-advanced-features#section-handle-links-in-your-own-app
 
-        String branchUrl = call.getString("url");
+        String branchUrl = call.getString("branch");
 
         if (branchUrl != null && !branchUrl.equals("")) {
             Intent intent = new Intent(getActivity(), getActivity().getClass());

--- a/ios/Plugin/BranchService.swift
+++ b/ios/Plugin/BranchService.swift
@@ -61,4 +61,13 @@ class BranchService {
     func setDMAParamsForEEA(eeaRegion: Bool, adPersonalizationConsent: Bool, adUserDataUsageConsent: Bool) -> Void {
         Branch.setDMAParamsForEEA(eeaRegion, adPersonalizationConsent: adPersonalizationConsent, adUserDataUsageConsent: adUserDataUsageConsent)
     }
+    
+    func handleUrl(url: String, completion: @escaping (Error?) -> Void) {
+        if let deepLinkUrl = URL(string: url) {
+            Branch.getInstance().handleDeepLink(deepLinkUrl)
+            completion(nil)
+        } else {
+            completion(NSError(domain: "Invalid URL", code: 400, userInfo: nil))
+        }
+    }
 }

--- a/ios/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin.m
@@ -16,4 +16,5 @@ CAP_PLUGIN(BranchDeepLinks, "BranchDeepLinks",
            CAP_PLUGIN_METHOD(getLatestReferringParams, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(getFirstReferringParams, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(setDMAParamsForEEA, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(handleUrl, CAPPluginReturnPromise);
 )

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -343,7 +343,7 @@ public class BranchDeepLinks: CAPPlugin {
 
     @objc func handleUrl(_ call: CAPPluginCall) {
         guard let url = call.getString("branch") else {
-            call.reject("URL object is required")
+            call.reject("The object passed must contain a 'branch' key with a string value")
             return
         }
 

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -340,4 +340,19 @@ public class BranchDeepLinks: CAPPlugin {
         branchService.setDMAParamsForEEA(eeaRegion: eeaRegion, adPersonalizationConsent: adPersonalizationConsent, adUserDataUsageConsent: adUserDataUsageConsent)
         call.resolve()
     }
+
+    @objc func handleUrl(_ call: CAPPluginCall) {
+        guard let url = call.getString("branch") else {
+            call.reject("URL object is required")
+            return
+        }
+
+        branchService.handleUrl(url: url) { error in
+            if let error = error {
+                call.reject(error.localizedDescription)
+            } else {
+                call.resolve()
+            }
+        }
+    }
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -11,7 +11,7 @@ export interface BranchReferringParamsResponse {
 }
 
 export interface BranchUrlParams {
-  url: string;
+  branch: string;
 }
 
 export interface BranchShortUrlAnalytics {


### PR DESCRIPTION
## Reference
INTENG-20755 - Exposing the Push Notification functions on the Capacitor Layer

## Summary
Fixed issues with Push Notifications not working on Android and the handleUrl method not being exposed on iOS. Changes include exposing the iOS function and addressing the Android bug.

## Motivation
This change addresses a bug affecting Push Notifications functionality. The issue can be replicated using the [sample project](https://github.com/vamsimadhav/ionic_app) provided. With the updated Capacitor SDK, the handleUrl issue as described will be resolved.

## Type Of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Testing Instructions
1) Clone the [sample project](https://github.com/vamsimadhav/ionic_app).
2) Follow the step-by-step guide [here](https://www.notion.so/brancheng/Step-by-Step-Guide-to-Set-Up-and-Run-the-Git-Repository-83138865e8e64fca9a0c0009221f42b6) to set up and run the app.
3) Click on the send notifications button within the app to trigger local notifications.
4) After integrating the updated SDK with the mentioned changes:
Verify that both iOS and Android logs correctly display data.

cc @BranchMetrics/saas-sdk-devs for visibility.
