### PR TITLE
[SDK-2525] Added CPP level support to Capacitor and release 8.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 Branch Capacitor SDK change log
 
 - 8.4.0
+
   - Exposed new method `setConsumerProtectionAttributionLevel` to set CPP level
-  - Branch Android SDK bumped to 5.15.0
-  - Branch iOS SDK bumped to 3.8.0
+  - Branch Android SDK bumped to 5.15.1
+  - Branch iOS SDK bumped to 3.9.0
   - Updated @capacitor/ios to 6.2.0
 
 - 8.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 Branch Capacitor SDK change log
 
+- 8.4.0
+  - Exposed new method `setConsumerProtectionAttributionLevel` to set CPP level
+  - Branch Android SDK bumped to 5.15.0
+  - Branch iOS SDK bumped to 3.8.0
+  - Updated @capacitor/ios to 6.2.0
+
 - 8.3.0
 
   - Branch Android SDK bumped to 5.13.0

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     implementation project(':capacitor-android')
     implementation 'androidx.annotation:annotation:1.4.0'
     implementation 'androidx.appcompat:appcompat:1.5.0'
-    api 'io.branch.sdk.android:library:5.15.0'
+    api 'io.branch.sdk.android:library:5.15.1'
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     implementation project(':capacitor-android')
     implementation 'androidx.annotation:annotation:1.4.0'
     implementation 'androidx.appcompat:appcompat:1.5.0'
-    api 'io.branch.sdk.android:library:5.13.0'
+    api 'io.branch.sdk.android:library:5.15.0'
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"

--- a/android/src/main/java/co/boundstate/BranchDeepLinks.java
+++ b/android/src/main/java/co/boundstate/BranchDeepLinks.java
@@ -18,6 +18,7 @@ import io.branch.referral.Branch;
 import io.branch.referral.BranchError;
 import io.branch.referral.BranchShareSheetBuilder;
 import io.branch.referral.BranchShortLinkBuilder;
+import io.branch.referral.Defines;
 import io.branch.referral.QRCode.BranchQRCode;
 import io.branch.referral.SharingHelper;
 import io.branch.referral.util.BRANCH_STANDARD_EVENT;
@@ -547,6 +548,37 @@ public class BranchDeepLinks extends Plugin {
         Branch branch = Branch.getInstance();
         branch.setDMAParamsForEEA(eeaRegion, adPersonalizationConsent, adUserDataUsageConsent);
 
+        call.resolve();
+    }
+
+    @PluginMethod
+    public void setConsumerProtectionAttributionLevel(PluginCall call) {
+        String level = call.getString("level");
+        if (level == null) {
+            call.reject("Must provide a valid attribution level");
+            return;
+        }
+
+        Defines.BranchAttributionLevel attributionLevel;
+        switch (level) {
+            case "FULL":
+                attributionLevel = Defines.BranchAttributionLevel.FULL;
+                break;
+            case "REDUCED":
+                attributionLevel = Defines.BranchAttributionLevel.REDUCED;
+                break;
+            case "MINIMAL":
+                attributionLevel = Defines.BranchAttributionLevel.MINIMAL;
+                break;
+            case "NONE":
+                attributionLevel = Defines.BranchAttributionLevel.NONE;
+                break;
+            default:
+                call.reject("Invalid attribution level provided");
+                return;
+        }
+
+        Branch.getInstance().setConsumerProtectionAttributionLevel(attributionLevel);
         call.resolve();
     }
 }

--- a/ios/Plugin/BranchService.swift
+++ b/ios/Plugin/BranchService.swift
@@ -70,4 +70,24 @@ class BranchService {
             completion(NSError(domain: "Invalid URL", code: 400, userInfo: nil))
         }
     }
+
+    func setConsumerProtectionAttributionLevel(level: String) -> Void {
+        var attributionLevel: BranchAttributionLevel
+        
+        switch level {
+        case "FULL":
+            attributionLevel = BranchAttributionLevel.full
+        case "REDUCED":
+            attributionLevel = BranchAttributionLevel.reduced
+        case "MINIMAL":
+            attributionLevel = BranchAttributionLevel.minimal
+        case "NONE":
+            attributionLevel = BranchAttributionLevel.none
+        default:
+            return
+        }
+        
+        Branch.getInstance().setConsumerProtectionAttributionLevel(attributionLevel)
+    }
+    
 }

--- a/ios/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin.m
@@ -17,4 +17,6 @@ CAP_PLUGIN(BranchDeepLinks, "BranchDeepLinks",
            CAP_PLUGIN_METHOD(getFirstReferringParams, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(setDMAParamsForEEA, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(handleUrl, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(setConsumerProtectionAttributionLevel, CAPPluginReturnPromise);
+           
 )

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -16,7 +16,7 @@ public class BranchDeepLinks: CAPPlugin {
                 object: nil
         )
         
-        Branch.getInstance().registerPluginName("Capacitor", version: "8.3.0")
+        Branch.getInstance().registerPluginName("Capacitor", version: "8.4.0")
     }
 
     @objc public func setBranchService(branchService: Any) {
@@ -355,4 +355,15 @@ public class BranchDeepLinks: CAPPlugin {
             }
         }
     }
+
+    @objc func setConsumerProtectionAttributionLevel(_ call: CAPPluginCall) {
+        guard let level = call.getString("level") else {
+            call.reject("Must provide a valid attribution level")
+            return
+        }
+        
+        branchService.setConsumerProtectionAttributionLevel(level: level)
+        call.resolve()
+    }
+
 }

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -4,7 +4,7 @@ def capacitor_pods
   use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
-  pod 'BranchSDK', '~> 3.8.0'
+  pod 'BranchSDK', '~> 3.9.0'
 end
 
 target 'Plugin' do

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -4,7 +4,7 @@ def capacitor_pods
   use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../node_modules/@capacitor/ios'
-  pod 'BranchSDK', '~> 3.6.5'
+  pod 'BranchSDK', '~> 3.8.0'
 end
 
 target 'Plugin' do

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,11 +1,11 @@
 PODS:
-  - BranchSDK (3.6.5)
-  - Capacitor (6.0.0):
+  - BranchSDK (3.8.0)
+  - Capacitor (6.2.0):
     - CapacitorCordova
-  - CapacitorCordova (6.0.0)
+  - CapacitorCordova (6.2.0)
 
 DEPENDENCIES:
-  - BranchSDK (~> 3.6.5)
+  - BranchSDK (~> 3.8.0)
   - "Capacitor (from `../node_modules/@capacitor/ios`)"
   - "CapacitorCordova (from `../node_modules/@capacitor/ios`)"
 
@@ -20,10 +20,10 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@capacitor/ios"
 
 SPEC CHECKSUMS:
-  BranchSDK: ef7d89062afb08b20f65d5b1633b215ee77ab77f
-  Capacitor: 559d073c4ca6c27f8e7002c807eea94c3ba435a9
-  CapacitorCordova: 8c4bfdf69368512e85b1d8b724dd7546abeb30af
+  BranchSDK: e517c334355e4d37f8f16b11213a76b0b2779ac6
+  Capacitor: 1f3c7b9802d958cd8c4eb63895fff85dff2e1eea
+  CapacitorCordova: b33e7f4aa4ed105dd43283acdd940964374a87d9
 
-PODFILE CHECKSUM: eacb5a70bea671c5a765cb96750ba8653a52d16b
+PODFILE CHECKSUM: 3484333e03f4f4ad335c9fb26d4170325705b824
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,11 +1,11 @@
 PODS:
-  - BranchSDK (3.8.0)
+  - BranchSDK (3.9.0)
   - Capacitor (6.2.0):
     - CapacitorCordova
   - CapacitorCordova (6.2.0)
 
 DEPENDENCIES:
-  - BranchSDK (~> 3.8.0)
+  - BranchSDK (~> 3.9.0)
   - "Capacitor (from `../node_modules/@capacitor/ios`)"
   - "CapacitorCordova (from `../node_modules/@capacitor/ios`)"
 
@@ -20,10 +20,10 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@capacitor/ios"
 
 SPEC CHECKSUMS:
-  BranchSDK: e517c334355e4d37f8f16b11213a76b0b2779ac6
+  BranchSDK: caa0aad74d39bcd08573661d13ae0821feecdada
   Capacitor: 1f3c7b9802d958cd8c4eb63895fff85dff2e1eea
   CapacitorCordova: b33e7f4aa4ed105dd43283acdd940964374a87d9
 
-PODFILE CHECKSUM: 3484333e03f4f4ad335c9fb26d4170325705b824
+PODFILE CHECKSUM: 8997a24b5d8780d5611e0cf2d1d4aa3cf1c5d2ae
 
 COCOAPODS: 1.16.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capacitor-branch-deep-links",
-  "version": "8.3.0",
+  "version": "8.4.0",
   "description": "Capacitor plugin for Branch.io deep links",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",
@@ -22,7 +22,7 @@
     "@capacitor/android": "^6.0.0",
     "@capacitor/cli": "^6.0.0",
     "@capacitor/core": "^6.0.0",
-    "@capacitor/ios": "^6.0.0",
+    "@capacitor/ios": "^6.2.0",
     "@ionic/prettier-config": "^1.0.0",
     "@ionic/swiftlint-config": "^1.0.0",
     "@rollup/plugin-node-resolve": "^8.1.0",

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -85,6 +85,8 @@ export interface BranchInitEvent extends BranchReferringParamsResponse {}
 
 export type BranchATTAuthorizationStatus = 0 | 1 | 2 | 3;
 
+export type BranchConsumerProtectionAttributionLevel = 'FULL' | 'REDUCED' | 'MINIMAL' | 'NONE';
+
 export interface BranchDeepLinksPlugin {
   addListener(
     eventName: 'init',
@@ -118,4 +120,5 @@ export interface BranchDeepLinksPlugin {
   getLatestReferringParams(): Promise<BranchReferringParamsResponse>;
   getFirstReferringParams(): Promise<BranchReferringParamsResponse>;
   setDMAParamsForEEA: (options: BranchDMAParams) => void;
+  setConsumerProtectionAttributionLevel(options: { level: BranchConsumerProtectionAttributionLevel }): Promise<void>;
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -109,6 +109,12 @@ export class BranchDeepLinksWeb
     );
   }
 
+  setConsumerProtectionAttributionLevel(_: { level: string }): Promise<void> {
+    return Promise.reject(
+      new Error('BranchDeepLinks does not have web implementation'),
+    );
+  }
+
   addListener(
     _eventName: 'init',
     _listenerFunc: (event: BranchInitEvent) => void,


### PR DESCRIPTION
## Reference
SDK-2525 -- Expose the CPP method in the JS layer

## Summary
Added support for setting the CPP level in the Capactir JS Layer. Also updated the native iOS and Android SDKs.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
To give clients access to the latest SDK features.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] New feature (non-breaking change which adds functionality)

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->
Install the `8.4.0-alpha.5` package and test the new method, `setConsumerProtectionAttributionLevel`.

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
